### PR TITLE
Create callbacks to be used for async. calls.

### DIFF
--- a/app/src/main/java/me/niccorder/news/data/ErrorCallback.java
+++ b/app/src/main/java/me/niccorder/news/data/ErrorCallback.java
@@ -1,0 +1,15 @@
+package me.niccorder.news.data;
+
+/**
+ * A callback to be used when we have successfully retrieved data from any repository in our
+ * application.
+ */
+public interface ErrorCallback {
+
+    /**
+     * Called when there is an error when gathering data from a repository request.
+     *
+     * @param error that occurred when gathering data.
+     */
+    void onError(Throwable error);
+}

--- a/app/src/main/java/me/niccorder/news/data/RepositoryCallback.java
+++ b/app/src/main/java/me/niccorder/news/data/RepositoryCallback.java
@@ -1,0 +1,23 @@
+package me.niccorder.news.data;
+
+/**
+ * A utility class to allow repository classes to use this as a data request callback. The reason
+ * why we split these into two is because in the future we may only want to listen for errors, as
+ * successful responses may not mean anything to us in the application.
+ *
+ * @param <T> type of the data in the response.
+ */
+public abstract class RepositoryCallback<T> implements SuccessCallback<T>, ErrorCallback {
+
+    @Override
+    public void onSuccess(T data) {
+        // Do nothing. We leave this blank because RepositoryCallback is a utility class used in the
+        // case a user only wants to implement onSuccess, or onError.
+    }
+
+    @Override
+    public void onError(Throwable error) {
+        // Do nothing. We leave this blank because RepositoryCallback is a utility class used in the
+        // case a user only wants to implement onSuccess, or onError.
+    }
+}

--- a/app/src/main/java/me/niccorder/news/data/SuccessCallback.java
+++ b/app/src/main/java/me/niccorder/news/data/SuccessCallback.java
@@ -1,0 +1,15 @@
+package me.niccorder.news.data;
+
+/**
+ * A callback to be used when we have successfully retrieved data from any repository in our
+ * application.
+ */
+public interface SuccessCallback<T> {
+
+    /**
+     * Called when the data request returned successfully.
+     *
+     * @param type of the data returned.
+     */
+    void onSuccess(T type);
+}


### PR DESCRIPTION
Data layer tasks (IO tasks) should always be ran on a thread different
from the main thread. This will allow us to follow the callback pattern
to integrate in asynchronous (or mocked async.) IO tasks in the future.

This is the first step in completing the PTR feature.

ISSUE #1